### PR TITLE
Re-checking of a fields maximum length

### DIFF
--- a/bootstrap-maxlength.js
+++ b/bootstrap-maxlength.js
@@ -214,10 +214,20 @@
                 }
             }
 
+            /**
+             *  This function retrieves the maximum length of currentInput
+             *
+             *  @param currentInput
+             *  @return {number}
+             *
+             */
+            function getMaxLength(currentInput){
+                return currentInput.attr('maxlength') || currentInput.attr('size');
+            }
             return this.each(function() {
 
                 var currentInput = $(this),
-                    maxLengthCurrentInput = currentInput.attr('maxlength') || currentInput.attr('size'),
+                    maxLengthCurrentInput = getMaxLength(currentInput),
                     maxLengthIndicator = $('<span></span>').css({
                         display: 'none',
                         position: 'absolute',
@@ -228,7 +238,7 @@
                 documentBody.append(maxLengthIndicator);
 
                 currentInput.focus(function() {
-                    var remaining = remainingChars(currentInput, maxLengthCurrentInput);
+                    var remaining = remainingChars(currentInput, maxLengthCurrentInput=getMaxLength(currentInput));
                     maxLengthIndicator.css({
                         zIndex: 99999
                     });
@@ -242,7 +252,7 @@
                 });
 
                 currentInput.keyup(function() {
-                    var remaining = remainingChars(currentInput, maxLengthCurrentInput),
+                    var remaining = remainingChars(currentInput, maxLengthCurrentInput=getMaxLength(currentInput)),
                         output = true;
                     if (options.validate && remaining < 0) {
                         output = false;


### PR DESCRIPTION
I found this great addon, and wanted to use it, but it just so happened, that the input fields maximum length could vary depending on the content that was input. This is a minor patch to make it happen.

It does lower the performance somewhat, but I don't think that by much.
