### PR TITLE
Fix reversed output variable

### DIFF
--- a/bootstrap-maxlength.js
+++ b/bootstrap-maxlength.js
@@ -64,9 +64,9 @@
            * @return {number}
            */
             function charsLeftThreshold(input, thereshold, maxlength) {
-                var output = false;
+                var output = true;
                 if (!options.alwaysShow && (maxlength - inputLength(input) > thereshold)) {
-                    output = true;
+                    output = false;
                 }
                 return output;
             }


### PR DESCRIPTION
The output variable setting was reversed and now has been reset back in the charsLeftThreshold(input, thereshold, maxlength) function.
