### PR TITLE
When called from here we are dealing with the count and not the input

### DIFF
--- a/bootstrap-maxlength.js
+++ b/bootstrap-maxlength.js
@@ -112,7 +112,7 @@
                     output += options.preText;
                 }
                 if (!options.showCharsTyped) {
-                    output += remainingChars(typedChars, maxLengthThisInput);
+                    output += maxLengthThisInput - typedChars;
                 }
                 else {
                     output += typedChars;


### PR DESCRIPTION
the remainingChars function expects the actual input, and is called as such from other locations. When within updateMaxLengthHTML, we already have the input length, so we can skip the function call (and the resulting error message) and do the subtraction inline.
