### PR TITLE
Update maxLengthIndicator position on window resize event

### DIFF
--- a/src/bootstrap-maxlength.js
+++ b/src/bootstrap-maxlength.js
@@ -270,6 +270,10 @@
                   maxLengthCurrentInput,
                   maxLengthIndicator;
 
+              $(window).resize(function() {
+                place(currentInput, maxLengthIndicator);
+              });
+
               currentInput.focus(function () {
                     var maxlengthContent = updateMaxLengthHTML(maxLengthCurrentInput, '0');
                     maxLengthCurrentInput = getMaxLength(currentInput);


### PR DESCRIPTION
Works both on mobiles and desktop. I believe jQuery .resize should be used instead of window.onresize as jQuery takes care of cross-browser compatibility.
