### PR TITLE
Fix error when maxLengthIndicator is not yet defined

### DIFF
--- a/src/bootstrap-maxlength.js
+++ b/src/bootstrap-maxlength.js
@@ -303,7 +303,9 @@
               });
 
                 currentInput.blur(function() {
-                    maxLengthIndicator.remove();
+                    if(maxLengthIndicator) {
+                        maxLengthIndicator.remove();
+                    }
                 });
 
                 currentInput.keyup(function() {


### PR DESCRIPTION
This is a really mean one.

When you are in IE and you are using any JavaScript that fixes HTML5 placeholders for IE, they are mostly using a .blur() at the end to "initialize" the script for an input field.

In IE this will trigger an error that maxLengthIndicator is not defined, thus can't call remove()
The event does not bubble in IE, so execution stops and the placeholder never appears.

My placeholder code is here (CoffeeScript): https://gist.github.com/maxschulze/5854036a8feef618af78
