### PR TITLE
fixed demo page for https

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,8 +228,8 @@
         <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
         alt="Fork me on GitHub">
     </a>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js"></script>
     <script src="assets/javascripts/highlight.js/highlight.pack.js"></script>
     <script src="bower_components/bootstrap-maxlength/bootstrap-maxlength.min.js"></script>
     <script>


### PR DESCRIPTION
The demo page was not working under https due too http urls. 
Replaced http includes with protocol-relative urls
