### PR TITLE
Changed jquery requirement to > 1.9.x in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "**/.*"
   ],
   "dependencies": {
-    "jquery": "~2.1.1"
+    "jquery": ">=1.9.x"
   },
   "devDependencies": {
     "qunit": "~1.15.0",


### PR DESCRIPTION
As per https://plugins.jquery.com/bootstrap-maxlength/
JQuery needed should be > 1.9
