### PR TITLE
Not hidden counter

### DIFF
--- a/src/bootstrap-maxlength.js
+++ b/src/bootstrap-maxlength.js
@@ -490,7 +490,7 @@
         });
 
         currentInput.on('blur', function () {
-          if (maxLengthIndicator && !options.showOnReady && !options.alwaysShow) {
+          if (maxLengthIndicator && !options.showOnReady) {
             maxLengthIndicator.remove();
           }
         });


### PR DESCRIPTION
If the 'always Show' is setted to 'false' (default).
It is not shown the counter.

If the 'alwaysShow' is setted to 'true'.
The display does not hide in the 'blur' event.