### PR TITLE
Indicator won’t hide on blur when `alwaysShow`

### DIFF
--- a/src/bootstrap-maxlength.js
+++ b/src/bootstrap-maxlength.js
@@ -491,7 +491,7 @@
         });
 
         currentInput.on('blur', function () {
-          if (maxLengthIndicator && !options.showOnReady && !options.alwaysShow) {
+          if (maxLengthIndicator && !options.showOnReady) {
             maxLengthIndicator.remove();
           }
         });


### PR DESCRIPTION
`alwaysShow` is meant to show the indicator as soon as the input gets focus, but that shouldn’t disable the indicator from hiding on blur.
This closes #124