### PR TITLE
fix event name for external autosize plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $('form').on('submit', function (e) {
 
 An example of triggering a `maxlength.reposition` event whenever an external autosize plugin resizes a textarea:
 ```javascript
-$('textarea').on('autosize.resized', function() {
+$('textarea').on('autosize:resized', function() {
     $(this).trigger('maxlength.reposition');
 });
 ```


### PR DESCRIPTION
In autosize plugin v4.0.0, triggered 'autosize:resized' event.
FYI: https://github.com/jackmoore/autosize/blob/4.0.0/src/autosize.js#L160